### PR TITLE
[GHA] Just run this project on java 21 as there is no actual source

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         cache: [maven]
         distribution: [temurin]
-        java: [17, 21, 22, 23-ea]
+        java: [21]
         os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
       max-parallel: 4


### PR DESCRIPTION
no reason to run multiple java versions when this is just a osgi bundle of resources.